### PR TITLE
Ignore null and undefined field values

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,10 @@ function postProcess(url, data) {
 
 	// Now map this to useful structures
 	Object.keys(data).forEach(function (originalKey) {
+		if (data[originalKey] === null || typeof data[originalKey] === 'undefined') {
+			return;
+		}
+
 		var key;
 		if (originalKey.startsWith('og')) {
 			key = stringToUnderscore(originalKey.substring(2)).substring(1);


### PR DESCRIPTION
These cause issues later on in the post-processing, and are not really required as part of the final model anyway.

Fixes the following crash:

```
/service/index.js:80
		if (data[originalKey].value) {
		                     ^

TypeError: Cannot read property 'value' of undefined
    at /service/index.js:80:24
    at Array.forEach (native)
    at postProcess (/service/index.js:69:20)
    at /service/index.js:165:22
    at done (/service/node_modules/open-graph-scraper/app.js:322:9)
    at /service/node_modules/open-graph-scraper/app.js:388:9
    at Request._callback (/service/node_modules/open-graph-scraper/app.js:619:7)
    at Request.self.callback (/service/node_modules/open-graph-scraper/node_modules/request/request.js:186:22)
    at emitTwo (events.js:87:13)
    at Request.emit (events.js:172:7)
```

@rogierslag Ready for review