### PR TITLE
Resolve the image relative to the canonical url

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,13 +60,15 @@ function defaultOutput(url) {
 function postProcess(url, data) {
 	var result = defaultOutput(url);
 
+	var canonicalUrl = data.ogUrl || url;
+
 	// Format images for their special cases
 	['ogImage', 'twitterImage'].forEach(function (key) {
 		if (data[key]) {
 			if (!data[key].url) {
 				delete data[key];
 			} else if (data[key].url) {
-				var imageUrl = resolveRelative(data[key].url, url);
+				var imageUrl = resolveRelative(data[key].url, canonicalUrl);
 				if (process.env.CAMO_KEY && process.env.CAMO_HOST) {
 					imageUrl = camoUrl(imageUrl);
 				}


### PR DESCRIPTION
for redirects as bitly, we want to resolve against the final domain, not the bit.ly link

@tiddolangerak @AlexKolpa @alexnederlof