### PR TITLE
Prevent opengraph from loading internal resources

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,9 @@
-ecmaFeatures:
-  modules: true
-  jsx: true
+
+parserOptions:
+  ecmaVersion: 2017
+  ecmaFeatures:
+    modules: true
+    jsx: true
 
 env:
   amd: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -542,6 +542,19 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
       "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
     },
+    "es6-promise": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+      "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "4.1.1"
+      }
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1129,6 +1142,11 @@
           }
         }
       }
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ipaddr.js": {
       "version": "1.5.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "camo-url": "^0.2.0",
     "elasticsearch": "^13.3.1",
+    "es6-promisify": "^5.0.0",
     "express": "^4.14.1",
+    "ip": "^1.1.5",
     "moment-timezone": "^0.5.11",
     "open-graph-scraper": "^2.5.4"
   },


### PR DESCRIPTION
This was fixes in another version before, but for some reason I forgot it here.

We should _not_ let opengraph fetch stuff from our internal network. Ever.