### PR TITLE
Fix for accept header

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,11 @@ function response(statusCode, response) {
 async function fetchFromRemote(urlToFetch) {
 	const options = {
 		url : encodeURI(urlToFetch),
-		timeout : HTTP_TIMEOUT
+		timeout : HTTP_TIMEOUT,
+		headers: {
+			'user-agent': 'opengraph-cacher <https://github.com/inventid/opengraph-cacher>',
+			accept: '*/*'
+		}
 	};
 	try {
 		const ogData = await ogs(options);
@@ -37,6 +41,7 @@ async function fetchFromRemote(urlToFetch) {
 			return response(statusCode, resultData);
 		}
 	} catch (e) {
+		log('ERROR', e);
 		return response(500, defaultOutput(urlToFetch));
 	}
 }


### PR DESCRIPTION
For pages do return a forbidden error if the accept header is not sent along. As such, we will now add it automatically.

Additionally this adds a default `user-agent` header